### PR TITLE
Added support for variable peripheral clock 1 for I2C

### DIFF
--- a/Inc/i2c_hal.h
+++ b/Inc/i2c_hal.h
@@ -15,7 +15,7 @@ typedef enum {
 	I2C_ERROR
 } I2C_ERROR_CODE;
 
-void i2c_init(I2C_TypeDef* I2C);
+void i2c_init(I2C_TypeDef* I2C, uint32_t pclk1);
 
 I2C_ERROR_CODE i2c_write(I2C_TypeDef* I2C, uint8_t addr, uint8_t* data, uint8_t len);
 uint8_t* i2c_read(I2C_TypeDef* I2C, uint8_t addr, uint8_t numBytes);

--- a/Inc/sht30.h
+++ b/Inc/sht30.h
@@ -23,7 +23,7 @@ typedef struct SensorValues
 	double temperature;
 } SensorValues_t;
 
-SHT30_t sht30_init(I2C_TypeDef* I2C, uint8_t addr);
+SHT30_t sht30_init(I2C_TypeDef* I2C, uint32_t pclk1, uint8_t addr);
 
 SensorValues_t sht30_get_sensor_value(SHT30_t* sensor, uint8_t repeatability, uint8_t clockStretching, uint8_t isC);
 

--- a/Src/main.c
+++ b/Src/main.c
@@ -27,7 +27,8 @@ void clock_init(void)
 	while (!(RCC->CFGR & RCC_CFGR_SWS_PLL)); // Wait for clock source to be set
 }
 
-/* Nokia Screen
+/*
+ * Nokia Screen
  * PA8: RST
  * PA4: NSS/CE
  * PA9: DC
@@ -37,7 +38,8 @@ void clock_init(void)
  * PA10: BL
  */
 
-/* SHT30
+/*
+ * SHT30 for sensor 1 (I2C1)
  * PB6: SCL
  * PB7: SDA
  */
@@ -50,7 +52,7 @@ int main(void)
 	PCD8544_t screen = pcd8544_init(GPIOA, RST_PIN, DC_PIN, BL_PIN, Vcc_PIN, 0x70, 0, 0b011); // Initialize screen
 	pcd8544_toggle_backlight(&screen); // Turn on screen backlight
 
-	SHT30_t sensor1 = sht30_init(I2C1, 0x44); // Initialize sensor 1 on I2C1
+	SHT30_t sensor1 = sht30_init(I2C1, 36000000, 0x44); // Initialize sensor 1 on I2C1
 
 	char temperatureStr[8], humidityStr[8]; // Initialize string buffers for temp and humidity, these are the strings sent to the screen
 	const char degreeSign[] = {0x80, 0x0}; // Initialize and define degree sign character (0x80 in default font, ending in null terminator)

--- a/Src/sht30.c
+++ b/Src/sht30.c
@@ -1,13 +1,13 @@
 
 #include "sht30.h"
 
-SHT30_t sht30_init(I2C_TypeDef* I2C, uint8_t addr)
+SHT30_t sht30_init(I2C_TypeDef* I2C, uint32_t pclk1, uint8_t addr)
 {
 	SHT30_t sensor;
 	sensor.I2C = I2C;
 	sensor.addr = addr;
 
-	i2c_init(I2C); // Initialize I2C peripheral
+	i2c_init(I2C, pclk1); // Initialize I2C peripheral
 	// The initialization time for I2C is greater than 1ms, so no need to wait for the SHT30 to enter idle mode (Maximum 1ms after power on)
 
 	return sensor;


### PR DESCRIPTION
I2C can be configured for any peripheral clock 1 speed (2MHz-36MHz) with the pclk1 variable in i2c_init()