### PR TITLE
Added I2C Interrupt Mode

### DIFF
--- a/Inc/i2c_hal.h
+++ b/Inc/i2c_hal.h
@@ -18,6 +18,9 @@ typedef enum {
 void i2c_init(I2C_TypeDef* I2C, uint32_t pclk1);
 
 I2C_ERROR_CODE i2c_write(I2C_TypeDef* I2C, uint8_t addr, uint8_t* data, uint8_t len);
+void i2c_write_it(I2C_TypeDef* I2C, uint8_t addr, uint8_t* data, uint8_t len);
+
 uint8_t* i2c_read(I2C_TypeDef* I2C, uint8_t addr, uint8_t numBytes);
+uint8_t* i2c_read_it(I2C_TypeDef* I2C, uint8_t addr, uint8_t numBytes);
 
 #endif /* I2C_HAL_H_ */

--- a/Src/sht30.c
+++ b/Src/sht30.c
@@ -59,13 +59,13 @@ static void start_measurement(SHT30_t* sensor, uint16_t command)
 {
 	// I2C write, with 16-bit measurement command
 	uint8_t commandPtr[] = {command >> 8, command & 0xFF};
-	i2c_write(sensor->I2C, sensor->addr, commandPtr, 2);
+	i2c_write_it(sensor->I2C, sensor->addr, commandPtr, 2);
 }
 
 static uint8_t* read_measurement(SHT30_t* sensor)
 {
 	// I2C read, with 16-bit temperature value, checksum, 16-bit humidity value, checksum
-	uint8_t* data = i2c_read(sensor->I2C, sensor->addr, 6);
+	uint8_t* data = i2c_read_it(sensor->I2C, sensor->addr, 6);
 	return data;
 }
 


### PR DESCRIPTION
 - Public functions: i2c_write_it() and i2c_read_it(), perform the same task as i2c_write() and i2c_read() but uses interrupts to signal when each part of the I2C signal is sent (instead of waiting in a while loop)
 - Enabled only event interrupts, since the buffer interrupts cannot be used with DMA, which will be implemented later
 - Added event IRQ handlers for I2C1 and I2C2, which call I2C_EV() to handle SB and ADDR events
 - Added static functions for interrupt mode in i2c_hal.c that correspond to the blocking functions (i2c_start_it(), i2c_send_addr_it(), i2c_send_data_it(), i2c_get_data_it())
 - The SHT30 sensors now use I2C in interrupt mode