### PR TITLE
Screen write optimize

### DIFF
--- a/Inc/pcd8544.h
+++ b/Inc/pcd8544.h
@@ -32,6 +32,7 @@ PCD8544_t pcd8544_init(GPIO_TypeDef* GPIOx, uint8_t RST_Pin, uint8_t DC_Pin, uin
 void pcd8544_toggle_backlight(PCD8544_t* screen);
 void pcd8544_write_string(PCD8544_t* screen, const char* str);
 void pcd8544_set_cursor(PCD8544_t* screen, uint8_t X, uint8_t Y);
+void pcd8544_set_cursor_string(PCD8544_t* screen, uint8_t X, uint8_t Y);
 void pcd8544_write_bitmap(PCD8544_t* screen, const uint8_t img[504]);
 
 #endif /* INC_PCD8544_H_ */

--- a/Src/main.c
+++ b/Src/main.c
@@ -67,6 +67,25 @@ int main(void)
 	const char degreeSign[] = {0x80, 0x0}; // Initialize and define degree sign character (0x80 in default font, ending in null terminator)
 	const char plusMinusSign[] = {0x81, 0x0}; // Initialize and plus-minus sign character (0x81)
 
+	// Set up parts of the screen that don't change
+	pcd8544_set_cursor(&screen, 0, 0);
+	pcd8544_write_string(&screen, "Terrarium 1:");
+	pcd8544_set_cursor_string(&screen, 4, 1);
+	pcd8544_write_string(&screen, degreeSign);
+	pcd8544_write_string(&screen, "F ");
+	pcd8544_set_cursor_string(&screen, 9, 1);
+	pcd8544_write_string(&screen, plusMinusSign);
+	pcd8544_write_string(&screen, "2%");
+
+	pcd8544_set_cursor(&screen, 0, 3);
+	pcd8544_write_string(&screen, "Terrarium 2:");
+	pcd8544_set_cursor_string(&screen, 4, 4);
+	pcd8544_write_string(&screen, degreeSign);
+	pcd8544_write_string(&screen, "F ");
+	pcd8544_set_cursor_string(&screen, 9, 4);
+	pcd8544_write_string(&screen, plusMinusSign);
+	pcd8544_write_string(&screen, "2%");
+
     while (1)
     {
     	SensorValues_t sensor1Vals = sht30_get_sensor_value(&sensor1, 1, 1, 0); // Get temp and humidity values from sensor 1
@@ -81,33 +100,22 @@ int main(void)
     	/*
     	 * Displays temp and humidity on the screen in form:
     	 *
-    	 * Temp.:XX.X°F
-    	 * Humidity:XX%
+    	 * Terrarium 1:
+    	 * XX.X°F XX%
     	 *
-    	 * Temp.:XX.X°F
-    	 * Humidity:XX%
+    	 * Terrarium 2:
+    	 * XX.X°F XX%
     	 */
-    	pcd8544_set_cursor(&screen, 0, 0);
-    	pcd8544_write_string(&screen, "Temp.:");
-    	pcd8544_write_string(&screen, temperature1Str);
-    	pcd8544_write_string(&screen, degreeSign);
-    	pcd8544_write_string(&screen, "F");
-    	pcd8544_set_cursor(&screen, 0, 1);
-    	pcd8544_write_string(&screen, "Humidity:");
-    	pcd8544_write_string(&screen, humidity1Str);
-    	pcd8544_write_string(&screen, plusMinusSign);
-    	pcd8544_write_string(&screen, "2%");
 
-    	pcd8544_set_cursor(&screen, 0, 3);
-    	pcd8544_write_string(&screen, "Temp.:");
-    	pcd8544_write_string(&screen, temperature2Str);
-    	pcd8544_write_string(&screen, degreeSign);
-    	pcd8544_write_string(&screen, "F");
+    	pcd8544_set_cursor(&screen, 0, 1);
+    	pcd8544_write_string(&screen, temperature1Str);
+    	pcd8544_set_cursor_string(&screen, 7, 1);
+    	pcd8544_write_string(&screen, humidity1Str);
+
     	pcd8544_set_cursor(&screen, 0, 4);
-    	pcd8544_write_string(&screen, "Humidity:");
+    	pcd8544_write_string(&screen, temperature2Str);
+    	pcd8544_set_cursor_string(&screen, 7, 4);
     	pcd8544_write_string(&screen, humidity2Str);
-    	pcd8544_write_string(&screen, plusMinusSign);
-    	pcd8544_write_string(&screen, "2%");
 
     	delay_ms(1000);
     }

--- a/Src/pcd8544.c
+++ b/Src/pcd8544.c
@@ -265,9 +265,18 @@ void pcd8544_write_string(PCD8544_t* screen, const char* str)
 
 }
 
+// Sets cursor position in pixels across (X) and banks (Y)
 void pcd8544_set_cursor(PCD8544_t* screen, uint8_t X, uint8_t Y)
 {
 	pcd8544_set_X_RAM(screen, X);
+	pcd8544_set_Y_RAM(screen, Y);
+}
+
+// Sets cursor position in the context of writing strings to the screen
+// Accounts for the width of characters in the default font
+void pcd8544_set_cursor_string(PCD8544_t* screen, uint8_t X, uint8_t Y)
+{
+	pcd8544_set_X_RAM(screen, X*6);
 	pcd8544_set_Y_RAM(screen, Y);
 }
 


### PR DESCRIPTION
 - Changed the layout of the screen slightly to label each terrarium, with temperature and humidity on the same line
 - Static screen elements ("Terrarium 1:", "°F", and "+-2%") are written to the screen only once, before the superloop
 - Added pcd8544_set_cursor_string() for use when writing strings to the screen; the unit of X is in characters (rather than pixels in pcd8544_set_cursor())