### PR TITLE
I2C Interrupt Mode Fix

### DIFF
--- a/Inc/i2c_hal.h
+++ b/Inc/i2c_hal.h
@@ -21,6 +21,6 @@ I2C_ERROR_CODE i2c_write(I2C_TypeDef* I2C, uint8_t addr, uint8_t* data, uint8_t 
 void i2c_write_it(I2C_TypeDef* I2C, uint8_t addr, uint8_t* data, uint8_t len);
 
 uint8_t* i2c_read(I2C_TypeDef* I2C, uint8_t addr, uint8_t* data, uint8_t numBytes);
-uint8_t* i2c_read_it(I2C_TypeDef* I2C, uint8_t addr, uint8_t* data, uint8_t numBytes);
+void i2c_read_it(I2C_TypeDef* I2C, uint8_t addr, uint8_t* data, uint8_t numBytes);
 
 #endif /* I2C_HAL_H_ */

--- a/Inc/i2c_hal.h
+++ b/Inc/i2c_hal.h
@@ -20,7 +20,7 @@ void i2c_init(I2C_TypeDef* I2C, uint32_t pclk1);
 I2C_ERROR_CODE i2c_write(I2C_TypeDef* I2C, uint8_t addr, uint8_t* data, uint8_t len);
 void i2c_write_it(I2C_TypeDef* I2C, uint8_t addr, uint8_t* data, uint8_t len);
 
-uint8_t* i2c_read(I2C_TypeDef* I2C, uint8_t addr, uint8_t numBytes);
-uint8_t* i2c_read_it(I2C_TypeDef* I2C, uint8_t addr, uint8_t numBytes);
+uint8_t* i2c_read(I2C_TypeDef* I2C, uint8_t addr, uint8_t* data, uint8_t numBytes);
+uint8_t* i2c_read_it(I2C_TypeDef* I2C, uint8_t addr, uint8_t* data, uint8_t numBytes);
 
 #endif /* I2C_HAL_H_ */

--- a/Inc/sht30.h
+++ b/Inc/sht30.h
@@ -10,6 +10,7 @@
 
 #include "main.h"
 #include "i2c_hal.h"
+#include "math.h" // Included for NAN definition
 
 typedef struct SHT30
 {
@@ -25,6 +26,7 @@ typedef struct SensorValues
 
 SHT30_t sht30_init(I2C_TypeDef* I2C, uint32_t pclk1, uint8_t addr);
 
-SensorValues_t sht30_get_sensor_value(SHT30_t* sensor, uint8_t repeatability, uint8_t clockStretching, uint8_t isC);
+void sht30_get_raw_sensor(SHT30_t* sensor, uint8_t repeatability, uint8_t clockStretching, uint8_t data[6]);
+SensorValues_t sht30_convert_sensor(uint8_t data[6], uint8_t isC);
 
 #endif /* SHT30_H_ */

--- a/Src/i2c_hal.c
+++ b/Src/i2c_hal.c
@@ -15,6 +15,16 @@
  * set in I2C_SR1 or when the STOPF bit is cleared
  */
 
+inline static void i2c_enable_it(I2C_TypeDef* I2C)
+{
+	I2C->CR2 |= I2C_CR2_ITBUFEN | I2C_CR2_ITEVTEN | I2C_CR2_ITERREN; // Enable Interrupts
+}
+
+inline static void i2c_disable_it(I2C_TypeDef* I2C)
+{
+	I2C->CR2 &= ~(I2C_CR2_ITBUFEN | I2C_CR2_ITEVTEN | I2C_CR2_ITERREN); // Disable Interrupts
+}
+
 // Master sends START condition
 // Assumes I2C is in slave mode, switches to master mode upon sending START
 static I2C_ERROR_CODE i2c_start(I2C_TypeDef* I2C)
@@ -27,15 +37,9 @@ static I2C_ERROR_CODE i2c_start(I2C_TypeDef* I2C)
 	return I2C_OK;
 }
 
-// Master sends START condition, uses I2C with interrupts
-static void i2c_start_it(I2C_TypeDef* I2C)
-{
-	I2C->CR1 |= I2C_CR1_START; // Sends START condition
-}
-
 // Master sends STOP condition
 // Used by both blocking and interrupt modes
-static void i2c_stop(I2C_TypeDef* I2C)
+inline static void i2c_stop(I2C_TypeDef* I2C)
 {
 	I2C->CR1 |= I2C_CR1_STOP; // Send STOP condition
 }
@@ -53,21 +57,6 @@ static I2C_ERROR_CODE i2c_send_addr(I2C_TypeDef* I2C, uint8_t addr, uint8_t LSB)
 	return I2C_OK;
 }
 
-// Data structures to store info for use with I2C interrupts; These structures should be set before calling i2c_start_it()
-volatile uint8_t currAddr[2] = {0, 0};
-volatile uint8_t currLSB[2] = {0, 0};
-volatile uint8_t* currData[2] = {0, 0};
-volatile uint16_t currLen[2] = {0, 0};
-
-// Master sends address of device it wants to communicate with; Only called in an interrupt request routine (IRQ)
-// Master enters transmitter (LSB=0) or receiver mode (LSB=1)
-static void i2c_send_addr_it(I2C_TypeDef* I2C)
-{
-	int i = I2C == I2C1 ? 0 : 1;
-	uint8_t msg = (currAddr[i] << 1) | (currLSB[i] & 0x1);
-	I2C->DR = msg; // Write msg to DR, sends addr on SDA
-}
-
 // Sends len bytes of data to previously called device
 // Assumes device address is already sent
 static I2C_ERROR_CODE i2c_send_data(I2C_TypeDef* I2C, uint8_t* data, uint16_t len)
@@ -83,24 +72,6 @@ static I2C_ERROR_CODE i2c_send_data(I2C_TypeDef* I2C, uint8_t* data, uint16_t le
 	return I2C_OK;
 }
 
-// Sends data from previously set currData to previously called device; Only called in an interrupt request routine (IRQ)
-static void i2c_send_data_it(I2C_TypeDef* I2C)
-{
-	uint16_t len = I2C == I2C1 ? currLen[0] : currLen[1];
-	volatile uint8_t* data = I2C == I2C1 ? currData[0] : currData[1];
-
-	for (int i = 0; i < len; i++) // Send all len # of data bytes
-	{
-		while (!(I2C->SR1 & I2C_SR1_TXE)); // Wait for the transmission buffer (TX) to be empty
-		I2C->DR = data[i]; // Write data to DR, sends data on SDA
-	}
-
-	while (!(I2C->SR1 & I2C_SR1_TXE)); // Wait for the transmission buffer (TX) to be empty
-	i2c_stop(I2C);
-	if (I2C == I2C1) NVIC_DisableIRQ(I2C1_EV_IRQn);
-	else if (I2C == I2C2) NVIC_DisableIRQ(I2C2_EV_IRQn);
-}
-
 // Returns the byte in the receive buffer (Rx), and responds with ACK (ack=1) or NACK (ack=0)
 static uint8_t i2c_get_data(I2C_TypeDef* I2C, uint8_t ack)
 {
@@ -110,28 +81,6 @@ static uint8_t i2c_get_data(I2C_TypeDef* I2C, uint8_t ack)
 	while (!(I2C->SR1 & I2C_SR1_RXNE)); // Wait for receive buffer to be not empty
 	uint8_t data = I2C->DR; // Get byte from receive buffer (by reading from data register)
 	return data;
-}
-
-// Puts retrieved data from device into the currData structure to be returned from i2c_read_it() later
-static void i2c_get_data_it(I2C_TypeDef* I2C)
-{
-	uint16_t len = I2C == I2C1 ? currLen[0] : currLen[1];
-	volatile uint8_t* data = I2C == I2C1 ? currData[0] : currData[1];
-
-	int i = 0;
-	for (; i < len - 1; i++)
-	{
-		while (!(I2C->SR1 & I2C_SR1_RXNE)); // Wait for receive buffer to be not empty
-		data[i] = I2C->DR; // Get byte from receive buffer (by reading from data register)
-	}
-
-	I2C->CR1 &= ~(I2C_CR1_ACK); // Sends NACK when reading from data register
-	while (!(I2C->SR1 & I2C_SR1_RXNE)); // Wait for receive buffer to be not empty
-	data[i] = I2C->DR; // Get byte from receive buffer (by reading from data register)
-
-	i2c_stop(I2C);
-	if (I2C == I2C1) NVIC_DisableIRQ(I2C1_EV_IRQn);
-	else if (I2C == I2C2) NVIC_DisableIRQ(I2C2_EV_IRQn);
 }
 
 // Sends a data byte through the I2C peripheral specified
@@ -159,7 +108,7 @@ I2C_ERROR_CODE i2c_write(I2C_TypeDef* I2C, uint8_t addr, uint8_t* data, uint8_t 
 
 // Reads numBytes bytes from the device
 // Returns a numBytes length array with the data
-uint8_t* i2c_read(I2C_TypeDef* I2C, uint8_t addr, uint8_t numBytes)
+uint8_t* i2c_read(I2C_TypeDef* I2C, uint8_t addr, uint8_t* data, uint8_t numBytes)
 {
 	while (I2C->SR2 & I2C_SR2_BUSY); // Wait for I2C bus to be not busy
 	if (i2c_start(I2C) != I2C_OK) // Send START condition
@@ -173,7 +122,6 @@ uint8_t* i2c_read(I2C_TypeDef* I2C, uint8_t addr, uint8_t numBytes)
 		return 0;
 	}
 
-	uint8_t* data = (uint8_t*) malloc(numBytes * sizeof(uint8_t)); // This data pointer is freed in sht30 library
 	int i = 0;
 	for (; i < numBytes - 1; i++) // Get data, and reply with ACK
 	{
@@ -187,67 +135,157 @@ uint8_t* i2c_read(I2C_TypeDef* I2C, uint8_t addr, uint8_t numBytes)
 	return data;
 }
 
-// Function called from I2Cx_EV_IRQHandler
-static void I2C_EV(I2C_TypeDef* I2C)
-{
-	if (I2C->SR1 & I2C_SR1_SB) // SB is set
-	{
-		i2c_send_addr_it(I2C);
-	}
-	else if (I2C->SR1 & I2C_SR1_ADDR) // ADDR is set
-	{
-		if (I2C->SR2); // Read SR2 to clear ADDR (only when ADDR is found to be set)
+// Data structures to store info for use with I2C interrupts; These structures should be set before calling i2c_start_it()
+volatile uint8_t currAddr[2] = {0, 0};
+volatile uint8_t currLSB[2] = {0, 0};
+volatile uint8_t* currData[2] = {0, 0};
+volatile uint16_t currLen[2] = {0, 0};
+volatile uint16_t currByte[2] = {0, 0}; // For the interrupt routine to know which byte it's currently on
 
-		int i = I2C == I2C1 ? 0 : 1;
-		if (currLSB[i]) i2c_get_data_it(I2C); // Read
-		else i2c_send_data_it(I2C); // Write
+// For knowning when to return from reading data, making sure all data is read into the provided buffer before returning control to the caller
+volatile uint8_t dataMutex[2] = {0, 0}; // 0->buffer ready, 1->buffer busy
+
+// Master sends START condition, uses I2C with interrupts
+inline static void i2c_start_it(I2C_TypeDef* I2C)
+{
+	I2C->CR1 |= I2C_CR1_START; // Sends START condition
+}
+
+// Master sends address of device it wants to communicate with; Only called in an interrupt request routine (IRQ)
+// Master enters transmitter (LSB=0) or receiver mode (LSB=1)
+static void i2c_send_addr_it(I2C_TypeDef* I2C, int i)
+{
+	I2C->DR = (currAddr[i] << 1) | (currLSB[i] & 0x1); // Write msg to DR, sends addr on SDA
+}
+
+// Sends data from previously set currData to previously called device; Only called in an interrupt request routine (IRQ)
+static void i2c_send_data_it(I2C_TypeDef* I2C, int i)
+{
+	I2C->DR = currData[i][currByte[i]++];
+}
+
+// Puts retrieved data from device into the currData structure to be returned from i2c_read_it() later
+inline static void i2c_get_data_it(I2C_TypeDef* I2C, int i)
+{
+	currData[i][currByte[i]++] = I2C->DR;
+}
+
+// Function called from I2Cx_EV_IRQHandler
+static void I2C_EV(I2C_TypeDef* I2C, int i)
+{
+	if (I2C->SR1 & I2C_SR1_ADDR) if (I2C->SR2); // Read SR2 to clear ADDR (making sure ADDR = 1 first)
+	else if (I2C->SR1 & I2C_SR1_SB) i2c_send_addr_it(I2C, i); // EV5: SB = 1
+	else if (I2C->SR1 & I2C_SR1_RXNE) // EV7: RxNE = 1
+	{
+		if (currByte[i] + 1 == currLen[i]) // EV7_1_2?: Read DataN
+		{
+			i2c_get_data_it(I2C, i); // Read DataN
+			// I2C Receive Stops
+			i2c_disable_it(I2C); // Disable Interrupts
+			dataMutex[i] = 0; // Release mutex here, give control back to return data
+		}
+		else if (I2C->SR1 & I2C_SR1_BTF) // EV7_1?: Method 2, communication stretched (RxNE = 1 and BTF = 1) to clear ACK
+		{
+			if (currByte[i] + 3 == currLen[i])
+			{
+				I2C->CR1 &= ~I2C_CR1_ACK; // Clear ACK
+				i2c_get_data_it(I2C, i); // Read DataN-2 from DR, this starts DataN reception in shift register
+				i2c_disable_it(I2C); // Disable Interrupts
+				i2c_stop(I2C); // Program STOP
+				i2c_get_data_it(I2C, i); // Read DataN-1
+				i2c_enable_it(I2C); // Enable Interrupts
+				// Wait for RxNE=1 and currByte[i] + 1 == currLen[i]
+			}
+			else
+			{
+				i2c_get_data_it(I2C, i);
+			}
+		}
 	}
-	// ADD10 not handled
+	else if (I2C->SR1 & I2C_SR1_TXE) // EV8 and EV8_1: TxE = 1
+	{
+		if (currByte[i] == currLen[i]) // EV8_2: No more bytes to write
+		{
+			i2c_disable_it(I2C); // Disable Interrupts
+			i2c_stop(I2C);
+		}
+		else
+		{
+			i2c_send_data_it(I2C, i);
+		}
+	}
+	else if (I2C->SR1 & I2C_SR1_BTF) // EV8_2
+	{
+		i2c_disable_it(I2C); // Disable Interrupts
+		i2c_stop(I2C);
+	}
 }
 
 // IRQ for I2Cx Events (SB, ADDR, ADD10, STOPF, BTF)
-void I2C1_EV_IRQHandler(void) { I2C_EV(I2C1); }
-void I2C2_EV_IRQHandler(void) { I2C_EV(I2C2); }
+void I2C1_EV_IRQHandler(void) { I2C_EV(I2C1, 0); }
+void I2C2_EV_IRQHandler(void) { I2C_EV(I2C2, 1); }
+
+static void I2C_ER(I2C_TypeDef* I2C, int i)
+{
+	i2c_stop(I2C);
+	dataMutex[i] = 0; // Release mutex
+	I2C->SR1 = ~(I2C_SR1_BERR | I2C_SR1_ARLO | I2C_SR1_AF | I2C_SR1_OVR | I2C_SR1_PECERR | I2C_SR1_TIMEOUT | I2C_SR1_SMBALERT); // Clear Error Flags
+	i2c_disable_it(I2C);
+}
+
+// IRQ for I2Cx Errors; Send STOP Condition and release mutex
+void I2C1_ER_IRQHandler(void) { I2C_ER(I2C1, 0); }
+void I2C2_ER_IRQHandler(void) { I2C_ER(I2C2, 1); }
 
 // Does the same thing as i2c_write(), but uses interrupts instead of blocking
 void i2c_write_it(I2C_TypeDef* I2C, uint8_t addr, uint8_t* data, uint8_t len)
 {
-	while (I2C->SR2 & I2C_SR2_BUSY); // Wait for I2C bus to be not busy
+	int i = (I2C == I2C1) ? 0 : 1;
 
-	if (I2C == I2C1) NVIC_EnableIRQ(I2C1_EV_IRQn);
-	else if (I2C == I2C2) NVIC_EnableIRQ(I2C2_EV_IRQn);
+	// Wait for the I2Cx bus to be not busy
+	while (I2C->SR2 & I2C_SR2_BUSY);
 
-	int i = I2C == I2C1 ? 0 : 1;
-	currLen[i] = len;
-	currData[i] = data;
-	currAddr[i] = addr;
+	// Set data structures for transmitter
 	currLSB[i] = 0;
+	currAddr[i] = addr;
+	currData[i] = data;
+	currLen[i] = len;
+	currByte[i] = 0;
 
-	i2c_start_it(I2C); // START condition kicks off all communication, interrupts handle the rest
+	// Enable Event, Buffer, and Error Interrupts
+	i2c_enable_it(I2C);
+
+	// Send START Condition
+	i2c_start_it(I2C);
 }
 
 // Does the same thing as i2c_read(), but uses interrupts instead of blocking
-uint8_t* i2c_read_it(I2C_TypeDef* I2C, uint8_t addr, uint8_t numBytes)
+uint8_t* i2c_read_it(I2C_TypeDef* I2C, uint8_t addr, uint8_t* data, uint8_t numBytes)
 {
-	while (I2C->SR2 & I2C_SR2_BUSY); // Wait for I2C bus to be not busy
+	int i = (I2C == I2C1) ? 0 : 1;
 
-	int i = 0;
-	if (I2C == I2C1) NVIC_EnableIRQ(I2C1_EV_IRQn);
-	else if (I2C == I2C2) NVIC_EnableIRQ(I2C2_EV_IRQn);
+	// Wait for the I2Cx bus to be not busy
+	while (I2C->SR2 & I2C_SR2_BUSY);
 
-	// Write to i2c_get_data_it vars
-	uint8_t* data = (uint8_t*) malloc(numBytes * sizeof(uint8_t));
+	// Program ACK = 1
+	I2C->CR1 |= I2C_CR1_ACK;
+
+	// Set data structures for transmitter
+	currLSB[i] = 1;
+	currAddr[i] = addr;
 	currData[i] = data;
 	currLen[i] = numBytes;
+	currByte[i] = 0;
+	dataMutex[i] = 1; // Give control of buffer to interrupts
 
-	// Write to i2c_send_addr_it vars
-	currAddr[i] = addr;
-	currLSB[i] = 1;
+	// Enable Event, Buffer, and Error Interrupts
+	i2c_enable_it(I2C);
 
-	I2C->CR1 |= I2C_CR1_ACK; // Enables sending of an ACK when reading from the data register (I2C->DR)
-
+	// Send START Condition
 	i2c_start_it(I2C);
-	while (I2C->SR2 & I2C_SR2_BUSY); // Wait for I2C bus to be not busy
+
+	// Wait for the I2Cx bus to be not busy and the data mutex to be surrendered, to make sure data is fully populated
+	while (dataMutex[i] == 1);
 	return data;
 }
 
@@ -277,16 +315,21 @@ void i2c_init(I2C_TypeDef* I2C, uint32_t pclk1)
 		while (!(GPIOB->IDR & (1 << 6))); // From errata, check if SDA is 1
 
 		GPIOB->CRL |= (0b11 << 26) | (0b11 << 30); // Set PB6 and PB7 to alternate function output open-drain
+
+		// Enable I2C1 NVIC Interrupts
+		NVIC_EnableIRQ(I2C1_EV_IRQn);
+		NVIC_EnableIRQ(I2C1_ER_IRQn);
 	}
 	else // I2C2
 	{
 		// Configure GPIO for I2C2
 		RCC->APB1ENR |= RCC_APB1ENR_I2C2EN; // Enable I2C2 Clock
+
 		// Uses default AFIO mapping for I2C2 (PB10->SCL, PB11->SDA), no need for remapping
 		I2C->CR1 &= ~(I2C_CR1_PE); // Make sure I2C peripheral is disabled
 		GPIOB->CRH |= (0b11 << 8) | (0b11 << 12); // Set PB10 and PB11 to output mode
 		GPIOB->ODR |= (1 << 10) | (1 << 11); // From errata, set ODR to 1
-		while (!(((GPIOB->IDR & (1 << 10))) && (GPIOB->IDR & (1 << 11)))); // From errata, check IDR for PB10 and PB11 are high
+ 		while (!(((GPIOB->IDR & (1 << 10))) && (GPIOB->IDR & (1 << 11)))); // From errata, check IDR for PB10 and PB11 are high
 		GPIOB->ODR &= ~(1 << 10); // From errata, set SCL ODR to 0
 		while (GPIOB->IDR & (1 << 10)); // From errata, check if SCL is 0
 		GPIOB->ODR &= ~(1 << 11); // From errata, set SDA to 0
@@ -297,6 +340,10 @@ void i2c_init(I2C_TypeDef* I2C, uint32_t pclk1)
 		while (!(GPIOB->IDR & (1 << 11))); // From errata, check if SDA is 1
 
 		GPIOB->CRH |= (0b11 << 10) | (0b11 << 14); // Set PB10 and PB11 to alternate function output open-drain
+
+		// Enable I2C2 NVIC Interrupts
+		NVIC_EnableIRQ(I2C2_EV_IRQn);
+		NVIC_EnableIRQ(I2C2_ER_IRQn);
 	}
 
 	// Reset I2C
@@ -304,7 +351,6 @@ void i2c_init(I2C_TypeDef* I2C, uint32_t pclk1)
 	I2C->CR1 &= ~(I2C_CR1_SWRST);
 
 	I2C->OAR1 |= (1 << 14); // I2C_OAR1 bit 14 "Should always be kept at 1 by software"
-	I2C->CR2 |= I2C_CR2_ITEVTEN; // Enable interrupts for events
 
 	/*
 	 * Example CCR Calculation with PCLK1 = 36MHz


### PR DESCRIPTION
- Interrupt mode reworked from referencing an2824, which factors in device errata
- Both I2C mode read request functions now take a buffer parameter initialized by the caller, to avoid malloc/free
- Made I2C Interrupt mode and sht30_get_raw_sensor() fully non-blocking, so both I2C buses can be use simultaneously
- Since both I2C buses can be used at the same time, the time it takes to get measurements from the sensors is cut in half (~12ms -> ~5ms)
- If a checksum is bad, then the corresponding value is set to NaN and is shown on the display