### PR TITLE
SPI DMA

### DIFF
--- a/Inc/spi_hal.h
+++ b/Inc/spi_hal.h
@@ -6,5 +6,6 @@
 
 void spi1_init(void);
 void spi_write(SPI_TypeDef* SPI, uint8_t data, GPIO_TypeDef* GPIOx);
+void spi_write_dma(SPI_TypeDef* SPI, uint8_t data, GPIO_TypeDef* GPIOx);
 
 #endif /* SPI_HAL_H_ */

--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 Displays and logs the environmental conditions in a terrarium using a STM32 microcontroller. Currently displays the temperature and humidity measurements taken in two separate terrariums on a pixels matrix LCD screen. 
 
 ## Planned Future Features
- - Use an ESP8266 to send logs to a ftp server, or store logs on a removeable, physical storage device (SD card, USB drive)
- - Use DMA with SPI peripherals, for more efficient use of the CPU
+ - Use an ESP8266 to send logs to a ftp server, or store logs on a removeable, physical storage device (USB drive)
  - Add temperature probes to monitor the soil temperature
  - When the display is off and no measurements are being taken, put the processor in a low-power mode

--- a/Src/main.c
+++ b/Src/main.c
@@ -115,11 +115,7 @@ void EXTI0_IRQHandler(void)
 {
 	if (displayOn == 0) // Wake display if it's off
 	{
-		// See discussion in TIM2_IRQHandler() for why display_sleep() is not called there, same applies for display_wake()
-		// The superloop checks whether TIM2 is enabled when displayOn = 0, which then calls display_wake()
-		// Unlike the TIM2 ISR, there is no noticeable lag time between pressing the button and display_wake()
-
-		// Set timer for how long to leave screen on, when timer ends turn the display back off
+		display_wake(); // We can use SPI DMA interrupts in this interrupt because SPI DMA interrupts have a higher pre-emption priority
 		TIM2->CNT = 0; // Make sure count is at 0
 		TIM2->CR1 |= TIM_CR1_CEN; // Enable TIM2 counter
 	}
@@ -134,15 +130,7 @@ void EXTI0_IRQHandler(void)
 void TIM2_IRQHandler(void)
 {
 	TIM2->CR1 &= ~TIM_CR1_CEN; // Disable TIM2 counter
-	// Not best to call display_sleep() from here because it sends SPI to screen, which uses interrupts
-	// Since we are currently in an interrupt, another interrupt cannot be triggered without enabling global interrupts, which is best to avoid if not needed
-	// Therefore, the superloop checks whether TIM2 is disabled when displayOn = 1, which then calls display_sleep()
-
-	// This has the side effect of having a lag time between the timer interrupt and display_sleep(), because the rest of the superloop needs to be executed before the display turns off
-	// This lag time can theoretically range from 0 to just over 1 second
-	// The delay_ms(1000) is where the program counter (pc) will be at most of the time, the 2nd biggest 'time waster' is temp/humidity sensors taking 15ms each loop (and SPI with the display is 546us)
-	// Since this interrupt has an equal chance of being tirggered from anywhere in the superloop, the expected value of this lag time is around 0.5 seconds
-	// For this context, the lag time is acceptable
+	display_sleep(); // We can use SPI DMA interrupts in this interrupt because SPI DMA interrupts have a higher pre-emption priority
 	TIM2->SR = ~TIM_SR_UIF; // Clear Update Interrupt Flag by writing 0 (rc_w0)
 }
 
@@ -176,6 +164,11 @@ void TIM2_IRQHandler(void)
 
 int main(void)
 {
+	NVIC_SetPriorityGrouping(4); // Set NVIC priority grouping to 4, to allow nested interrupts (3 bits pre-emptive priority, 1 bit sub-priority)
+	NVIC_SetPriority(TIM2_IRQn, NVIC_EncodePriority(4, 1, 0)); // pre-emptive = 1, sub-priority = 0
+	NVIC_SetPriority(EXTI0_IRQn, NVIC_EncodePriority(4, 1, 1)); // pre-emptive = 1, sub-priority = 1
+	NVIC_SetPriority(DMA1_Channel3_IRQn, NVIC_EncodePriority(4, 0, 0)); // pre-emptive = 0, sub-priority = 0, to be able to be nested in TIM2 and EXTI0 ISRs
+
 	clock_init(); // Initialize clock to 72 MHz
 	delay_init(); // Initialize delay functions
 	timer2_init(); // Initialize timer 2
@@ -194,20 +187,14 @@ int main(void)
 	char temperature1Str[5], humidity1Str[3]; // Initialize string buffers for temp and humidity from sensor 1
 	char temperature2Str[5], humidity2Str[3]; // Initialize string buffers for temp and humidity from sensor 2
 
-	// Start TIM2 to turn off the display after ~10 sec, since the display is already on upon start
+	// Start TIM2 to turn off the display after 10 sec, since the display is already on upon start
 	TIM2->CR1 |= TIM_CR1_CEN;
 
     while (1)
     {
     	if (displayOn) // Update display if on
     	{
-    		if (!(TIM2->CR1 & TIM_CR1_CEN)) // If timer 2 is off
-    		{
-    			display_sleep();
-    			continue; // continues execution back at while (1), skipping everything below
-    		}
-
-        	sht30_get_raw_sensor(&sensor1, 1, 1, sensor1Data); // Get temp and humidity values from sensor 1
+    		sht30_get_raw_sensor(&sensor1, 1, 1, sensor1Data); // Get temp and humidity values from sensor 1
         	sht30_get_raw_sensor(&sensor2, 1, 1, sensor2Data); // Get temp and humidity values from sensor 2
 
         	// Wait for both I2C buses to be free
@@ -243,10 +230,6 @@ int main(void)
         	pcd8544_write_string(&screen, humidity2Str);
 
         	delay_ms(1000);
-    	}
-    	else if (TIM2->CR1 & TIM_CR1_CEN) // If displayOn = 0 and timer 2 is on
-    	{
-    		display_wake();
     	}
     }
 }

--- a/Src/pcd8544.c
+++ b/Src/pcd8544.c
@@ -160,7 +160,6 @@ PCD8544_t pcd8544_init(GPIO_TypeDef* GPIOx, uint8_t RST_Pin, uint8_t DC_Pin, uin
 	pcd8544_set_temperature_control(&screen, TC);
 	pcd8544_set_bias(&screen, BS);
 	pcd8544_function_set(&screen, 0, 0, 0);
-	pcd8544_set_display_control(&screen, 1, 0);
 
 	return screen;
 }
@@ -171,7 +170,7 @@ static void send_spi(PCD8544_t* screen, uint8_t data, uint8_t DC)
 	if (DC & 0x1) screen->GPIOx->ODR |= (1 << 9);
 	else screen->GPIOx->ODR &= ~(1 << 9);
 
-	spi_write(SPI1, data, screen->GPIOx);
+	spi_write_dma(SPI1, data, screen->GPIOx);
 }
 
 // H=0 or H=1

--- a/Src/spi_hal.c
+++ b/Src/spi_hal.c
@@ -30,6 +30,15 @@ void spi1_init(void)
 			| SPI_CR1_MSTR
 			| SPI_CR1_BR_2;
 
+	// Configure DMA with SPI, since SPI is used to only transmit (in this program), we only need to enable the SPI Tx DMA channel
+	RCC->AHBENR |= RCC_AHBENR_DMA1EN; // Enable DMA Clock
+	DMA1_Channel3->CPAR = (uint32_t) &SPI1->DR; // Set peripheral register address in DMA_CPARx
+	DMA1_Channel3->CCR |= DMA_CCR_DIR | DMA_CCR_TCIE; // Configure data transfer direction (memory to peripheral) and interrupts in DMA_CCRx
+	SPI1->CR2 |= SPI_CR2_TXDMAEN; // Enable DMA in SPI_CR2
+
+	// Enable NVIC for DMA Interrupts
+	NVIC_EnableIRQ(DMA1_Channel3_IRQn);
+
 	// Enable SPI
 	SPI1->CR1 |= SPI_CR1_SPE;
 }
@@ -40,6 +49,33 @@ void spi_write(SPI_TypeDef* SPI, uint8_t data, GPIO_TypeDef* GPIOx)
 	GPIOx->ODR &= ~(1 << 4); // Set Enable to 0
 	SPI->DR = data; // The transmit sequence begins when a byte is written in the Tx Buffer
 	while (!(SPI->SR & SPI_SR_TXE)); // Wait for Tx buffer to be empty
-	while( SPI->SR & SPI_SR_BSY );  // Wait until SPI not busy
+	while (SPI->SR & SPI_SR_BSY);  // Wait until SPI not busy
+	GPIOx->ODR |= (1 << 4); // Set Enable to 1
+}
+
+volatile uint8_t dma_in_progress = 0; // Mutex used to ensure a DMA transmission currently in progress is not overwritten by the next one
+void DMA1_Channel3_IRQHandler(void)
+{
+	DMA1_Channel3->CCR &= ~DMA_CCR_EN; // Disable DMA Channel
+	DMA1->IFCR = DMA_IFCR_CTCIF3; // Clear DMA Global Flag
+	dma_in_progress = 0; // Surrender mutex
+}
+
+void spi_write_dma(SPI_TypeDef* SPI, uint8_t data, GPIO_TypeDef* GPIOx)
+{
+	while (dma_in_progress); // Wait until last DMA transfer is complete
+	GPIOx->ODR &= ~(1 << 4); // Set Enable to 0
+
+	// Only transmitting, just need to enable the SPI Tx DMA channel
+	DMA1_Channel3->CMAR = (uint32_t) &data; // Set memory address in DMA_CMARx
+	DMA1_Channel3->CNDTR = 1; // Configure total number of data to be transferred in DMA_CNDTRx (1 byte)
+	DMA1_Channel3->CCR |= DMA_CCR_EN; // Activate channel by setting enable bit in DMA_CCRx, this sends data
+	dma_in_progress = 1; // Give mutex to DMA1_Channel3 IRQ
+
+	while (dma_in_progress); // Wait for IRQ to give back mutex
+
+	// These spinlocks are required to avoid corrupting the last transmission (rm0008 pg. 719)
+	while (!(SPI->SR & SPI_SR_TXE)); // Wait until TxE = 1
+	while(SPI->SR & SPI_SR_BSY); // Wait until BSY = 0
 	GPIOx->ODR |= (1 << 4); // Set Enable to 1
 }


### PR DESCRIPTION
- Added spi_write_dma() to send SPI communication using DMA, to take some load off the CPU
- The PCD8544 driver uses SPI DMA
- Configured NVIC Priority Grouping and priorities for TIM2, EXTI0, and DMA1_Channel3, so that SPI DMA can nest an interrupt in a TIM2 or EXTI interrupt (because DMA1_Channel3 has a higher pre-emptive priority)